### PR TITLE
feat: add highlights

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -115,8 +115,8 @@ export const Channels = defComponent(
  *
  * Highlights can be used to collect links in a space or pins in a channel.
  * */
-export const HighlightedMessages = defComponent(
-  "highlightedMessages:01JQC43903866AKE4CX1ZZJ2RD",
+export const HighlightedItem = defComponent(
+  "highlightedItem:01JQC43903866AKE4CX1ZZJ2RD",
   LoroMovableList<EntityIdStr>
 );
 

--- a/src/components.ts
+++ b/src/components.ts
@@ -110,6 +110,17 @@ export const Channels = defComponent(
 );
 
 /**
+ * An ordered list of Entity IDs for a {@linkcode Collection} of highlighted
+ * Roomy messages or announcements.
+ *
+ * Highlights can be used to collect links in a space or pins in a channel.
+ * */
+export const HighlightedMessages = defComponent(
+  "highlightedMessages:01JQC43903866AKE4CX1ZZJ2RD",
+  LoroMovableList<EntityIdStr>
+);
+
+/**
  * An ordered list of Roomy threads or thread {@linkcode Collection}s.
  * */
 export const Threads = defComponent(

--- a/src/index.ts
+++ b/src/index.ts
@@ -463,12 +463,12 @@ export class Space extends NamedEntity {
     );
   }
   /** All highlighted messages or announcements in a Roomy space. */
-  get highlights(): EntityList<NamedEntity> {
+  get highlights(): EntityList<TimelineItem> {
     return new EntityList(
       this.peer,
       this.entity,
-      c.HighlightedMessages,
-      NamedEntity
+      c.HighlightedItem,
+      TimelineItem
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,6 +462,15 @@ export class Space extends NamedEntity {
       NamedEntity
     );
   }
+  /** All highlighted messages or announcements in a Roomy space. */
+  get highlights(): EntityList<NamedEntity> {
+    return new EntityList(
+      this.peer,
+      this.entity,
+      c.HighlightedMessages,
+      NamedEntity
+    );
+  }
 
   /** The global list of channels in the space, separate from the i. */
   get channels(): EntityList<Channel> {


### PR DESCRIPTION
Adds a HighlightedItem component to Spaces that can be used for aggregating collections of messages or announcements globally, like a /links timeline.